### PR TITLE
FBTweakCategory: Add update and reset methods.

### DIFF
--- a/FBTweak/FBTweak.h
+++ b/FBTweak/FBTweak.h
@@ -132,7 +132,7 @@ typedef id FBTweakValue;
 
 /**
   @abstract Adds an observer to the tweak.
-  @param object The observer. Must not be nil.
+  @param observer The observer. Must not be nil.
   @discussion A weak reference is taken on the observer.
  */
 - (void)addObserver:(id<FBTweakObserver>)observer;

--- a/FBTweak/FBTweakCategory.h
+++ b/FBTweak/FBTweakCategory.h
@@ -33,7 +33,6 @@ typedef void (^FBTweakCategoryUpdateBlock)(NSError * _Nullable error);
  */
 - (instancetype)initWithName:(NSString *)name tweakCollections:(NSArray<FBTweakCollection *> *)tweakCollections NS_DESIGNATED_INITIALIZER;
 
-
 /**
   @abstract The name of the category.
  */
@@ -42,7 +41,7 @@ typedef void (^FBTweakCategoryUpdateBlock)(NSError * _Nullable error);
 /**
   @abstract The collections contained in this category.
  */
-@property (nonatomic, copy, readonly) NSArray<FBTweakCollection *> *tweakCollections;
+@property (nonatomic, copy) NSArray<FBTweakCollection *> *tweakCollections;
 
 /**
   @abstract Fetches a collection by name.

--- a/FBTweak/FBTweakCategory.h
+++ b/FBTweak/FBTweakCategory.h
@@ -62,6 +62,11 @@ typedef void (^FBTweakCategoryUpdateBlock)(NSError * _Nullable error);
 - (void)removeTweakCollection:(FBTweakCollection *)tweakCollection;
 
 /**
+ @abstract Resets all tweaks in \c tweakCollections to their default value.
+ */
+- (void)reset;
+
+/**
  @abstract Asynchronously updates \c tweakCollections to the latest value, and calls \c completion
  when done. Error is reported by the means of \c completion's \c error argument, which is set upon
  an error or \c nil otherwise.

--- a/FBTweak/FBTweakCategory.h
+++ b/FBTweak/FBTweakCategory.h
@@ -9,7 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class FBTweakCollection;
+
+/// Block to be called when a category update operation has been completed.
+typedef void (^FBTweakCategoryUpdateBlock)(NSError * _Nullable error);
 
 /**
   @abstract A named grouping of collections.
@@ -30,13 +35,13 @@
 /**
   @abstract The collections contained in this category.
  */
-@property (nonatomic, copy, readonly) NSArray *tweakCollections;
+@property (nonatomic, copy, readonly) NSArray<FBTweakCollection *> *tweakCollections;
 
 /**
   @abstract Fetches a collection by name.
   @param name The collection name to find.
  */
-- (FBTweakCollection *)tweakCollectionWithName:(NSString *)name;
+- (FBTweakCollection * _Nullable)tweakCollectionWithName:(NSString *)name;
 
 /**
  @abstract Adds a tweak collection to the category.
@@ -50,4 +55,16 @@
  */
 - (void)removeTweakCollection:(FBTweakCollection *)tweakCollection;
 
+/**
+ @abstract Asynchronously updates \c tweakCollections to the latest value, and calls \c completion
+ when done. Error is reported by the means of \c completion's \c error argument, which is set upon
+ an error or \c nil otherwise.
+ @param completion Completion block to be called when the update is complete.
+ @discussion When the update operation is complete, is it expected that the \c tweakCollection will
+ be up-to-date.
+ */
+- (void)updateWithCompletion:(FBTweakCategoryUpdateBlock)completion;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/FBTweak/FBTweakCategory.h
+++ b/FBTweak/FBTweakCategory.h
@@ -21,11 +21,18 @@ typedef void (^FBTweakCategoryUpdateBlock)(NSError * _Nullable error);
  */
 @interface FBTweakCategory : NSObject <NSCoding>
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
   @abstract Creates a tweak category.
-  @discussion This is the designated initializer.
  */
 - (instancetype)initWithName:(NSString *)name;
+
+/**
+ @abstract Creates a tweak category with an initial tweak collections.
+ */
+- (instancetype)initWithName:(NSString *)name tweakCollections:(NSArray<FBTweakCollection *> *)tweakCollections NS_DESIGNATED_INITIALIZER;
+
 
 /**
   @abstract The name of the category.

--- a/FBTweak/FBTweakCategory.m
+++ b/FBTweak/FBTweakCategory.m
@@ -32,14 +32,17 @@
             tweakCollections:(NSArray<FBTweakCollection *> *)tweakCollections {
   if ((self = [super init])) {
     _name = [name copy];
-
-    _orderedCollections = [tweakCollections mutableCopy];
-    _namedCollections = [[NSMutableDictionary alloc] initWithCapacity:4];
-    for (FBTweakCollection *tweakCollection in _orderedCollections) {
-      [_namedCollections setObject:tweakCollection forKey:tweakCollection.name];
-    }
+    self.tweakCollections = tweakCollections;
   }
   return self;
+}
+
+- (void)setTweakCollections:(NSArray<FBTweakCollection *> *)tweakCollections {
+  _orderedCollections = [tweakCollections mutableCopy];
+  _namedCollections = [[NSMutableDictionary alloc] initWithCapacity:4];
+  for (FBTweakCollection *tweakCollection in _orderedCollections) {
+    [_namedCollections setObject:tweakCollection forKey:tweakCollection.name];
+  }
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder

--- a/FBTweak/FBTweakCategory.m
+++ b/FBTweak/FBTweakCategory.m
@@ -70,4 +70,8 @@
   [_namedCollections removeObjectForKey:tweakCollection.name];
 }
 
+- (void)updateWithCompletion:(FBTweakCategoryUpdateBlock)completion {
+  completion(nil);
+}
+
 @end

--- a/FBTweak/FBTweakCategory.m
+++ b/FBTweak/FBTweakCategory.m
@@ -7,6 +7,7 @@
  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import "FBTweak.h"
 #import "FBTweakCategory.h"
 #import "FBTweakCollection.h"
 
@@ -71,6 +72,16 @@
 {
   [_orderedCollections removeObject:tweakCollection];
   [_namedCollections removeObjectForKey:tweakCollection.name];
+}
+
+- (void)reset {
+  for (FBTweakCollection *collection in self.tweakCollections) {
+    for (FBTweak *tweak in collection.tweaks) {
+      if (!tweak.isAction) {
+        tweak.currentValue = nil;
+      }
+    }
+  }
 }
 
 - (void)updateWithCompletion:(FBTweakCategoryUpdateBlock)completion {

--- a/FBTweak/FBTweakCategory.m
+++ b/FBTweak/FBTweakCategory.m
@@ -18,27 +18,27 @@
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
   NSString *name = [coder decodeObjectForKey:@"name"];
-  
-  if ((self = [self initWithName:name])) {
-    _orderedCollections = [[coder decodeObjectForKey:@"collections"] mutableCopy];
-    
-    for (FBTweakCollection *tweakCollection in _orderedCollections) {
-      [_namedCollections setObject:tweakCollection forKey:tweakCollection.name];
-    }
-  }
-  
-  return self;
+  NSArray<FBTweakCollection *> *collections = [coder decodeObjectForKey:@"collections"];
+
+  return [self initWithName:name tweakCollections:collections];
 }
 
 - (instancetype)initWithName:(NSString *)name
 {
+  return [self initWithName:name tweakCollections:@[]];
+}
+
+- (instancetype)initWithName:(NSString *)name
+            tweakCollections:(NSArray<FBTweakCollection *> *)tweakCollections {
   if ((self = [super init])) {
     _name = [name copy];
-    
-    _orderedCollections = [[NSMutableArray alloc] initWithCapacity:4];
+
+    _orderedCollections = [tweakCollections mutableCopy];
     _namedCollections = [[NSMutableDictionary alloc] initWithCapacity:4];
+    for (FBTweakCollection *tweakCollection in _orderedCollections) {
+      [_namedCollections setObject:tweakCollection forKey:tweakCollection.name];
+    }
   }
-  
   return self;
 }
 

--- a/FBTweak/FBTweakStore.m
+++ b/FBTweak/FBTweakStore.m
@@ -82,13 +82,7 @@
 - (void)reset
 {
   for (FBTweakCategory *category in self.tweakCategories) {
-    for (FBTweakCollection *collection in category.tweakCollections) {
-      for (FBTweak *tweak in collection.tweaks) {
-        if (!tweak.isAction) {
-          tweak.currentValue = nil;
-        }
-      }
-    }
+    [category reset];
   }
 }
 


### PR DESCRIPTION
This PR adds more functionality to the `FBTweakCategory` object and enables it to act as a front for an updateable data source, while still keeping all existing functionality.