### PR TITLE
UITableView cells: use UITableViewCellStyleSubtitle for readability.

### DIFF
--- a/FBTweak/_FBEditableTweakDictionaryViewController.m
+++ b/FBTweak/_FBEditableTweakDictionaryViewController.m
@@ -63,7 +63,7 @@
   static NSString *_FBTweakDictionaryViewControllerCellIdentifier = @"_FBTweakDictionaryViewControllerCellIdentifier";
   UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:_FBTweakDictionaryViewControllerCellIdentifier];
   if (cell == nil) {
-    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:_FBTweakDictionaryViewControllerCellIdentifier];
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:_FBTweakDictionaryViewControllerCellIdentifier];
   }
   
   NSArray *allKeys = [self allTweakKeys];

--- a/FBTweak/_FBEditableTweakTableViewCell.m
+++ b/FBTweak/_FBEditableTweakTableViewCell.m
@@ -49,7 +49,7 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
 - (instancetype)initWithStyle:(UITableViewCellStyle)style
               reuseIdentifier:(NSString *)reuseIdentifier
 {
-  if ((self = [super initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:reuseIdentifier])) {
+  if ((self = [super initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:reuseIdentifier])) {
     _accessoryView = [[UIView alloc] init];
 
     _switch = [[UISwitch alloc] init];

--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -34,7 +34,7 @@ typedef void (^FBTweakTableViewCellBlock)(_FBTweakTableViewCell *cell, id value)
 
 - (instancetype)initWithStyle:(UITableViewCellStyle)style
               reuseIdentifier:(NSString *)reuseIdentifier {
-  if ((self = [super initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:reuseIdentifier])) {
+  if ((self = [super initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:reuseIdentifier])) {
     self.detailTextLabel.textColor = [UIColor blackColor];
     for (NSString *keyToObserve in [[self class] keyPathMapping]) {
       [self addObserver:self forKeyPath:keyToObserve


### PR DESCRIPTION
Previously we used UITableViewCellStyleValue1 which causes long strings
to be truncated, the UITableViewCellStyleSubtitle style allows longer
strings to be shown.