### PR TITLE
TableViewCells: use default color for details text.

### DIFF
--- a/FBTweak/_FBEditableTweakTableViewCell.m
+++ b/FBTweak/_FBEditableTweakTableViewCell.m
@@ -67,8 +67,6 @@ typedef NS_ENUM(NSUInteger, _FBTweakTableViewCellMode) {
     _stepper = [[UIStepper alloc] init];
     [_stepper addTarget:self action:@selector(_stepperChanged:) forControlEvents:UIControlEventValueChanged];
     [_accessoryView addSubview:_stepper];
-    
-    self.detailTextLabel.textColor = [UIColor blackColor];
   }
 
   return self;

--- a/FBTweak/_FBTweakTableViewCell.m
+++ b/FBTweak/_FBTweakTableViewCell.m
@@ -41,7 +41,6 @@ typedef void (^FBTweakTableViewCellBlock)(_FBTweakTableViewCell *cell, id value)
 - (instancetype)initWithStyle:(UITableViewCellStyle)style
               reuseIdentifier:(NSString *)reuseIdentifier {
   if ((self = [super initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:reuseIdentifier])) {
-    self.detailTextLabel.textColor = [UIColor blackColor];
     for (NSString *keyToObserve in [[self class] keyPathMapping]) {
       [self addObserver:self forKeyPath:keyToObserve
                 options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew


### PR DESCRIPTION
The color of the details text was hard coded to black which makes it
unreadable in dark mode. Use the default color so it will look good
in any case.