### PR TITLE
FBTweak: Archive value after it passed possibleValues validation.

### DIFF
--- a/FBTweak/FBTweak.m
+++ b/FBTweak/FBTweak.m
@@ -198,8 +198,8 @@
 
   // we can't store UIColor to the plist file. That is why we archive value to the NSData.
   NSError *error;
-  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:currentValue requiringSecureCoding:YES
-                                                   error:&error];
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self.currentValue
+                                       requiringSecureCoding:YES error:&error];
   NSAssert(data != nil, @"Failed to archive value with error: %@", error);
   [[NSUserDefaults standardUserDefaults] setObject:data forKey:self.identifier];
 }


### PR DESCRIPTION
Until now, if `currentValue` was set to a persistent tweak, if that
value wasn't one of the possible values, `currentValue` would be set to
`defaultValue` instead. However, the persisted value would still be the
value that was set, meaning, a value that isn't one of the possible
values. This commit changes it by persisting the value after it passed
the possible values validation.
