### PR TITLE
FBTweak: Ignore persisted value if its class isn't the default value's.

### DIFF
--- a/FBTweak/FBTweak.m
+++ b/FBTweak/FBTweak.m
@@ -180,13 +180,22 @@
 - (instancetype)initWithIdentifier:(NSString *)identifier name:(NSString *)name
                       defaultValue:(FBTweakValue)defaultValue {
   if (self = [super initWithIdentifier:identifier name:name defaultValue:defaultValue]) {
+    id currentValue;
     NSData *archivedValue = [[NSUserDefaults standardUserDefaults] objectForKey:identifier];
     if (archivedValue != nil && [archivedValue isKindOfClass:[NSData class]]) {
-      self.currentValue =
+      currentValue =
           [NSKeyedUnarchiver unarchivedObjectOfClasses:[FBPersistentTweak validValueClasses]
                                               fromData:archivedValue error:nil];
     } else {
-      self.currentValue = archivedValue;
+      currentValue = archivedValue;
+    }
+
+    // Using \c class instead of \c classForKeyedArchiver might lead to unexpected behaviour because
+    // defaultValue might be a hidden class like \c NSTaggedPointerString, in which case the check
+    // will fail. \c classForKeyedArchiver will return the class we want to check against.
+    if (!self.defaultValue ||
+        [currentValue isKindOfClass:[self.defaultValue classForKeyedArchiver]]) {
+      self.currentValue = currentValue;
     }
   }
 


### PR DESCRIPTION
There can be a mismatch between a tweak's default value and its current
value, if the default value was changed at a later point for example. To
fix this discrepancy, the persisted value is loaded as the tweak's
current value only if if it has the same kind of class as the default
value's class.
