### PR TITLE
FBTweak: Add editableFromUI flag.

### DIFF
--- a/FBTweak/FBTweak.h
+++ b/FBTweak/FBTweak.h
@@ -151,6 +151,11 @@ typedef id FBTweakValue;
  */
 @property (readwrite, nonatomic, nullable) FBTweakValue precisionValue;
 
+/**
+ @abstract Flag that used to block the option of editing from the tweak.
+ */
+@property (readwrite, nonatomic) BOOL editableFromUI;
+
 @end
 
 /**

--- a/FBTweak/FBTweak.m
+++ b/FBTweak/FBTweak.m
@@ -99,6 +99,7 @@
 @synthesize possibleValues = _possibleValues;
 @synthesize precisionValue = _precisionValue;
 @synthesize stepValue = _stepValue;
+@synthesize editableFromUI = _editableFromUI;
 
 - (instancetype)initWithIdentifier:(NSString *)identifier name:(NSString *)name
                       defaultValue:(FBTweakValue)defaultValue {
@@ -106,6 +107,7 @@
     _identifier = identifier;
     _name = name;
     _defaultValue = defaultValue;
+    _editableFromUI = YES;
   }
 
   return self;

--- a/FBTweak/_FBTweakCollectionViewController.m
+++ b/FBTweak/_FBTweakCollectionViewController.m
@@ -53,10 +53,15 @@
 - (Class)tweakCellForTweak:(id<FBTweak>)tweak {
   if ([tweak conformsToProtocol:@protocol(FBActionTweak)]) {
     return [_FBActionTweakTableViewCell class];
-  } else if ([tweak conformsToProtocol:@protocol(FBEditableTweak)]) {
+  } else if ([self editableTweak:tweak]) {
     return [_FBEditableTweakTableViewCell class];
   }
   return [_FBTweakTableViewCell class];
+}
+
+- (BOOL)editableTweak:(id<FBTweak>)tweak {
+  return [tweak conformsToProtocol:@protocol(FBEditableTweak)] &&
+      ((id<FBEditableTweak>)tweak).editableFromUI;
 }
 
 - (void)dealloc
@@ -181,7 +186,7 @@
       block();
     }
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
-  } else if ([tweak conformsToProtocol:@protocol(FBEditableTweak)]) {
+  } else if ([self editableTweak:tweak]) {
     id<FBEditableTweak> editableTweak = (id<FBEditableTweak>)tweak;
     if ([editableTweak.possibleValues isKindOfClass:[NSDictionary class]]) {
       _FBEditableTweakDictionaryViewController *vc = [[_FBEditableTweakDictionaryViewController alloc] initWithEditableTweak:editableTweak];


### PR DESCRIPTION
Used to block the option of editing from the tweak.
Credit to @byohay.